### PR TITLE
Add unit tests for components and SVG assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,10 @@
   "version": "2.1.123",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
-    "react-svg-unique-id": "^1.3.3",
-    "web-vitals": "^1.0.1"
+    "react-svg-unique-id": "^1.3.3"
   },
   "scripts": {
     "build": "react-scripts build",
@@ -19,7 +15,8 @@
     "eject": "react-scripts eject",
     "predeploy": "yarn build",
     "dev": "react-scripts start",
-    "test": "react-scripts test"
+    "test": "react-scripts test",
+    "lint": "eslint 'src/**/*.js'"
   },
   "eslintConfig": {
     "extends": [
@@ -40,6 +37,9 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
     "gh-pages": "^3.2.3"
   }
 }

--- a/src/assets/svg/BookingWidgetSVG.test.js
+++ b/src/assets/svg/BookingWidgetSVG.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import BookingWidgetSVG from './BookingWidgetSVG';
+
+describe('BookingWidgetSVG', () => {
+  it('renders an SVG element', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<BookingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies classProp correctly', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<BookingWidgetSVG classProp="test-class" onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('test-class');
+  });
+
+  it('calls onClick with true when clicked', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<BookingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    fireEvent.click(svg);
+    expect(mockOnClick).toHaveBeenCalledWith(true);
+  });
+
+  it('has role="button" for accessibility', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<BookingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('role', 'button');
+  });
+
+  it('renders with correct dimensions', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<BookingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '375');
+    expect(svg).toHaveAttribute('height', '375');
+  });
+});

--- a/src/assets/svg/CloseIconSVG.test.js
+++ b/src/assets/svg/CloseIconSVG.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import CloseIcon from './CloseIconSVG';
+
+describe('CloseIconSVG', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<CloseIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('renders with correct viewBox', () => {
+    const { container } = render(<CloseIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 16 16');
+  });
+
+  it('renders two line elements for the X shape', () => {
+    const { container } = render(<CloseIcon />);
+    const lines = container.querySelectorAll('line');
+    expect(lines).toHaveLength(2);
+  });
+
+  it('renders lines with correct stroke width', () => {
+    const { container } = render(<CloseIcon />);
+    const lines = container.querySelectorAll('line');
+    lines.forEach(line => {
+      expect(line).toHaveAttribute('stroke-width', '2');
+    });
+  });
+});

--- a/src/assets/svg/LeftArrowSVG.test.js
+++ b/src/assets/svg/LeftArrowSVG.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import LeftArrowSVG from './LeftArrowSVG';
+
+describe('LeftArrowSVG', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<LeftArrowSVG />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies classProp correctly', () => {
+    const { container } = render(<LeftArrowSVG classProp="test-class" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('LeftArrowSVG');
+    expect(svg).toHaveClass('test-class');
+  });
+
+  it('renders without classProp', () => {
+    const { container } = render(<LeftArrowSVG />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('LeftArrowSVG');
+  });
+
+  it('renders with correct dimensions', () => {
+    const { container } = render(<LeftArrowSVG />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '400.004');
+    expect(svg).toHaveAttribute('height', '400.004');
+  });
+
+  it('renders with correct viewBox', () => {
+    const { container } = render(<LeftArrowSVG />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 400.004 400.004');
+  });
+
+  it('contains a path element', () => {
+    const { container } = render(<LeftArrowSVG />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+  });
+});

--- a/src/assets/svg/ReferralWidgetSVG.test.js
+++ b/src/assets/svg/ReferralWidgetSVG.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ReferralWidgetSVG from './ReferralWidgetSVG';
+
+describe('ReferralWidgetSVG', () => {
+  it('renders an SVG element', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<ReferralWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies classProp correctly', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<ReferralWidgetSVG classProp="test-class" onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('test-class');
+  });
+
+  it('calls onClick with true when clicked', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<ReferralWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    fireEvent.click(svg);
+    expect(mockOnClick).toHaveBeenCalledWith(true);
+  });
+
+  it('has role="button" for accessibility', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<ReferralWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('role', 'button');
+  });
+
+  it('renders with correct dimensions', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<ReferralWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '375');
+    expect(svg).toHaveAttribute('height', '375');
+  });
+});

--- a/src/assets/svg/TrackingWidgetSVG.test.js
+++ b/src/assets/svg/TrackingWidgetSVG.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TrackingWidgetSVG from './TrackingWidgetSVG';
+
+describe('TrackingWidgetSVG', () => {
+  it('renders an SVG element', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<TrackingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies classProp correctly', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<TrackingWidgetSVG classProp="test-class" onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('test-class');
+  });
+
+  it('calls onClick with true when clicked', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<TrackingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    fireEvent.click(svg);
+    expect(mockOnClick).toHaveBeenCalledWith(true);
+  });
+
+  it('has role="button" for accessibility', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<TrackingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('role', 'button');
+  });
+
+  it('renders with correct dimensions', () => {
+    const mockOnClick = jest.fn();
+    const { container } = render(<TrackingWidgetSVG onClick={mockOnClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '375');
+    expect(svg).toHaveAttribute('height', '375');
+  });
+});

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('App', () => {
+  it('renders without crashing', () => {
+    render(<App />);
+  });
+
+  it('renders Muntra logo', () => {
+    render(<App />);
+    const logo = screen.getByAltText('Muntra Logo');
+    expect(logo).toBeInTheDocument();
+  });
+
+  it('renders Help button', () => {
+    render(<App />);
+    const helpButton = screen.getByText('Help');
+    expect(helpButton).toBeInTheDocument();
+  });
+
+  it('renders Muntra Pixel button', () => {
+    render(<App />);
+    const pixelButton = screen.getByText('Muntra Pixel');
+    expect(pixelButton).toBeInTheDocument();
+  });
+
+  it('renders Booking Widget button', () => {
+    render(<App />);
+    const bookingButton = screen.getByText('Booking Widget');
+    expect(bookingButton).toBeInTheDocument();
+  });
+
+  it('renders Referral Widget button', () => {
+    render(<App />);
+    const referralButton = screen.getByText('Referral Widget');
+    expect(referralButton).toBeInTheDocument();
+  });
+
+  it('does not show back button on home page', () => {
+    const { container } = render(<App />);
+    const backButton = container.querySelector('.backButtonContainer');
+    expect(backButton).not.toBeInTheDocument();
+  });
+
+  it('shows BookingWidget when Booking Widget button is clicked', () => {
+    render(<App />);
+    const bookingButton = screen.getByText('Booking Widget');
+    fireEvent.click(bookingButton);
+    expect(screen.getByText('Muntra Booking Widget Docs')).toBeInTheDocument();
+  });
+
+  it('shows back button when navigating to BookingWidget', () => {
+    const { container } = render(<App />);
+    const bookingButton = screen.getByText('Booking Widget');
+    fireEvent.click(bookingButton);
+    const backButton = container.querySelector('.backButtonContainer');
+    expect(backButton).toBeInTheDocument();
+  });
+
+  it('shows TrackingWidget when Muntra Pixel button is clicked', () => {
+    render(<App />);
+    const pixelButton = screen.getByText('Muntra Pixel');
+    fireEvent.click(pixelButton);
+    expect(screen.getByText('Muntra Pixel Docs')).toBeInTheDocument();
+  });
+
+  it('shows ReferralWidget when Referral Widget button is clicked', () => {
+    render(<App />);
+    const referralButton = screen.getByText('Referral Widget');
+    fireEvent.click(referralButton);
+    expect(screen.getByText('Muntra Referral Widget Docs')).toBeInTheDocument();
+  });
+
+  it('returns to home page when back button is clicked', () => {
+    const { container } = render(<App />);
+    const bookingButton = screen.getByText('Booking Widget');
+    fireEvent.click(bookingButton);
+
+    const backButton = container.querySelector('.backButtonContainer');
+    fireEvent.click(backButton);
+
+    expect(screen.getByText('Muntra Pixel')).toBeInTheDocument();
+    expect(screen.queryByText('Muntra Booking Widget Docs')).not.toBeInTheDocument();
+  });
+
+  it('toggles help menu when Help button is clicked', () => {
+    const { container } = render(<App />);
+    const helpButton = screen.getByText('Help');
+
+    // Initially help menu should be closed
+    let helpMenu = container.querySelector('.HelpMenuContainer');
+    expect(helpMenu).not.toHaveClass('HelpMenuContainerOpen');
+
+    // Click to open
+    fireEvent.click(helpButton);
+    helpMenu = container.querySelector('.HelpMenuContainer');
+    expect(helpMenu).toHaveClass('HelpMenuContainerOpen');
+
+    // Click to close
+    fireEvent.click(helpButton);
+    helpMenu = container.querySelector('.HelpMenuContainer');
+    expect(helpMenu).not.toHaveClass('HelpMenuContainerOpen');
+  });
+
+  it('navigates via SVG click on BookingWidgetSVG', () => {
+    const { container } = render(<App />);
+    const svgButtons = container.querySelectorAll('svg[role="button"]');
+    // BookingWidgetSVG is the second one (TrackingWidgetSVG, BookingWidgetSVG, ReferralWidgetSVG)
+    const bookingSvg = svgButtons[1];
+    fireEvent.click(bookingSvg);
+    expect(screen.getByText('Muntra Booking Widget Docs')).toBeInTheDocument();
+  });
+
+  it('navigates via SVG click on TrackingWidgetSVG', () => {
+    const { container } = render(<App />);
+    const svgButtons = container.querySelectorAll('svg[role="button"]');
+    // TrackingWidgetSVG is the first one
+    const trackingSvg = svgButtons[0];
+    fireEvent.click(trackingSvg);
+    expect(screen.getByText('Muntra Pixel Docs')).toBeInTheDocument();
+  });
+
+  it('navigates via SVG click on ReferralWidgetSVG', () => {
+    const { container } = render(<App />);
+    const svgButtons = container.querySelectorAll('svg[role="button"]');
+    // ReferralWidgetSVG is the third one
+    const referralSvg = svgButtons[2];
+    fireEvent.click(referralSvg);
+    expect(screen.getByText('Muntra Referral Widget Docs')).toBeInTheDocument();
+  });
+
+  it('hides homepage content when on a widget page', () => {
+    render(<App />);
+    const bookingButton = screen.getByText('Booking Widget');
+    fireEvent.click(bookingButton);
+
+    expect(screen.queryByAltText('Muntra Logo')).not.toBeInTheDocument();
+    expect(screen.queryByText('Muntra Pixel')).not.toBeInTheDocument();
+  });
+
+  it('has link to muntra website on logo', () => {
+    render(<App />);
+    const logo = screen.getByAltText('Muntra Logo');
+    const link = logo.closest('a');
+    expect(link).toHaveAttribute('href', 'https://about.muntra.se');
+  });
+});

--- a/src/components/BookingWidget/index.css
+++ b/src/components/BookingWidget/index.css
@@ -188,11 +188,6 @@ th {
 [hidden] {
   display: none !important;
 }
-.pure-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
 .auto-margin {
   margin: auto;
 }
@@ -289,10 +284,6 @@ pre code {
   white-space: pre-wrap;
   background-color: transparent;
   border-radius: 0;
-}
-.pre-scrollable {
-  max-height: 340px;
-  overflow-y: scroll;
 }
 
 @media (max-width: 992px) {

--- a/src/components/BookingWidget/index.test.js
+++ b/src/components/BookingWidget/index.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BookingWidget from './index';
+
+describe('BookingWidget', () => {
+  beforeEach(() => {
+    // Clean up any scripts added to document.body
+    document.body.innerHTML = '';
+  });
+
+  it('renders without crashing', () => {
+    render(<BookingWidget />);
+  });
+
+  it('renders main header', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('Muntra Booking Widget Docs')).toBeInTheDocument();
+  });
+
+  it('renders Information section', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('Information')).toBeInTheDocument();
+  });
+
+  it('renders important whitelist notice', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText(/IMPORTANT: MUNTRA PERSONNEL MUST WHITELIST YOUR DOMAIN/)).toBeInTheDocument();
+  });
+
+  it('renders Deployment to website section', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('Deployment to website')).toBeInTheDocument();
+  });
+
+  it('adds script to document body on mount', () => {
+    render(<BookingWidget />);
+    const scripts = document.body.querySelectorAll('script');
+    const muntraScript = Array.from(scripts).find(
+      script => script.src === 'https://muntra-dev.github.io/index.js'
+    );
+    expect(muntraScript).toBeTruthy();
+    expect(muntraScript.async).toBe(true);
+  });
+
+  it('renders example for all caregivers at clinic', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('All caregivers at clinic')).toBeInTheDocument();
+  });
+
+  it('renders example for specific caregiver', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('Specific caregiver')).toBeInTheDocument();
+  });
+
+  it('renders widget divs with muntra_clinic_id', () => {
+    const { container } = render(<BookingWidget />);
+    const widgetDivs = container.querySelectorAll('[muntra_clinic_id]');
+    expect(widgetDivs.length).toBeGreaterThan(0);
+  });
+
+  it('renders with page-body class', () => {
+    const { container } = render(<BookingWidget />);
+    const pageBody = container.querySelector('.page-body');
+    expect(pageBody).toBeInTheDocument();
+  });
+
+  it('renders without caregivers example', () => {
+    render(<BookingWidget />);
+    expect(screen.getByText('Without caregivers at clinic')).toBeInTheDocument();
+  });
+});

--- a/src/components/HelpMenu.js
+++ b/src/components/HelpMenu.js
@@ -6,7 +6,6 @@ const HelpMenu = ({ isOpen, handleClick }) => {
     <>
       <div
         className={`HelpMenuContainer${isOpen ? " HelpMenuContainerOpen" : ""}`}
-        isOpen={isOpen}
       >
         <div style={{ margin: "5px 28px" }}>
           {" "}

--- a/src/components/HelpMenu.test.js
+++ b/src/components/HelpMenu.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HelpMenu from './HelpMenu';
+
+describe('HelpMenu', () => {
+  it('renders without crashing', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={false} handleClick={mockHandleClick} />);
+  });
+
+  it('applies closed class when isOpen is false', () => {
+    const mockHandleClick = jest.fn();
+    const { container } = render(<HelpMenu isOpen={false} handleClick={mockHandleClick} />);
+    const menuContainer = container.querySelector('.HelpMenuContainer');
+    expect(menuContainer).toBeInTheDocument();
+    expect(menuContainer).not.toHaveClass('HelpMenuContainerOpen');
+  });
+
+  it('applies open class when isOpen is true', () => {
+    const mockHandleClick = jest.fn();
+    const { container } = render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const menuContainer = container.querySelector('.HelpMenuContainer');
+    expect(menuContainer).toHaveClass('HelpMenuContainerOpen');
+  });
+
+  it('calls handleClick when close icon is clicked', () => {
+    const mockHandleClick = jest.fn();
+    const { container } = render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const closeButton = container.querySelector('.UploadIconContainer');
+    fireEvent.click(closeButton);
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Educational section heading', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    expect(screen.getByText('Educational')).toBeInTheDocument();
+  });
+
+  it('renders Support section heading', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    expect(screen.getByText('Support')).toBeInTheDocument();
+  });
+
+  it('renders FreeCodeCamp link with correct href', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const link = screen.getByText('FreeCodeCamp');
+    expect(link).toHaveAttribute('href', 'https://www.freecodecamp.org/learn/responsive-web-design/');
+  });
+
+  it('renders W3 Schools link with correct href', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const link = screen.getByText('W3 Schools');
+    expect(link).toHaveAttribute('href', 'https://www.w3schools.com/css/default.asp');
+  });
+
+  it('renders support email link', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const emailLink = screen.getByText(/support@muntra.se/);
+    expect(emailLink).toHaveAttribute('href', 'mailto:support@muntra.se');
+  });
+
+  it('renders AnyDesk download links', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    expect(screen.getByText('Windows')).toHaveAttribute('href', 'https://download.anydesk.com/AnyDesk.exe');
+    expect(screen.getByText('Mac')).toHaveAttribute('href', 'https://download.anydesk.com/anydesk.dmg');
+  });
+
+  it('renders medical device disclaimer text', () => {
+    const mockHandleClick = jest.fn();
+    render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    expect(screen.getByText(/Muntra is an approved medical device/)).toBeInTheDocument();
+  });
+
+  it('renders CloseIcon component', () => {
+    const mockHandleClick = jest.fn();
+    const { container } = render(<HelpMenu isOpen={true} handleClick={mockHandleClick} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/src/components/ReferralWidget/index.test.js
+++ b/src/components/ReferralWidget/index.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReferralWidget from './index';
+
+describe('ReferralWidget', () => {
+  beforeEach(() => {
+    // Clean up any scripts added to document.body
+    document.body.innerHTML = '';
+  });
+
+  it('renders without crashing', () => {
+    render(<ReferralWidget />);
+  });
+
+  it('renders main header', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Muntra Referral Widget Docs')).toBeInTheDocument();
+  });
+
+  it('renders Information section', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Information')).toBeInTheDocument();
+  });
+
+  it('renders important whitelist notice', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText(/IMPORTANT: MUNTRA PERSONNEL MUST WHITELIST YOUR DOMAIN/)).toBeInTheDocument();
+  });
+
+  it('renders Deployment to website section', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Deployment to website')).toBeInTheDocument();
+  });
+
+  it('adds script to document body on mount', () => {
+    render(<ReferralWidget />);
+    const scripts = document.body.querySelectorAll('script');
+    const muntraScript = Array.from(scripts).find(
+      script => script.src === 'https://muntra-dev.github.io/referral-page/index.js'
+    );
+    expect(muntraScript).toBeTruthy();
+    expect(muntraScript.async).toBe(true);
+  });
+
+  it('renders widget placement example section', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Widget placement example')).toBeInTheDocument();
+  });
+
+  it('renders placing a widget heading', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Placing a widget on a page')).toBeInTheDocument();
+  });
+
+  it('renders required attributes section', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Required attributes:')).toBeInTheDocument();
+  });
+
+  it('renders optional attributes section', () => {
+    render(<ReferralWidget />);
+    expect(screen.getByText('Optional attributes:')).toBeInTheDocument();
+  });
+
+  it('renders referral widget div with clinic id', () => {
+    const { container } = render(<ReferralWidget />);
+    const widgetDiv = container.querySelector('.muntra-referral-widget');
+    expect(widgetDiv).toBeInTheDocument();
+    expect(widgetDiv).toHaveAttribute('muntra_clinic_id', '51');
+  });
+
+  it('renders with page-body class', () => {
+    const { container } = render(<ReferralWidget />);
+    const pageBody = container.querySelector('.page-body');
+    expect(pageBody).toBeInTheDocument();
+  });
+});

--- a/src/components/TrackingWidget/index.test.js
+++ b/src/components/TrackingWidget/index.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TrackingWidget from './index';
+
+describe('TrackingWidget', () => {
+  beforeEach(() => {
+    // Clean up any scripts added to document.body
+    document.body.innerHTML = '';
+  });
+
+  it('renders without crashing', () => {
+    render(<TrackingWidget />);
+  });
+
+  it('renders main header', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Muntra Pixel Docs')).toBeInTheDocument();
+  });
+
+  it('renders Information section', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Information')).toBeInTheDocument();
+  });
+
+  it('renders description about Muntra pixel', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText(/The Muntra pixel is a piece of code/)).toBeInTheDocument();
+  });
+
+  it('renders Tracking Widget heading', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Tracking Widget')).toBeInTheDocument();
+  });
+
+  it('renders Deployment to website section', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Deployment to website')).toBeInTheDocument();
+  });
+
+  it('adds script to document body on mount', () => {
+    render(<TrackingWidget />);
+    const scripts = document.body.querySelectorAll('script');
+    const muntraScript = Array.from(scripts).find(
+      script => script.src === 'https://muntra-dev.github.io/index.js'
+    );
+    expect(muntraScript).toBeTruthy();
+    expect(muntraScript.async).toBe(true);
+  });
+
+  it('renders Troubleshooting section', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
+  });
+
+  it('renders Checklist section', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Checklist')).toBeInTheDocument();
+  });
+
+  it('renders Checking whitelisting section', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText('Checking whitelisting')).toBeInTheDocument();
+  });
+
+  it('renders pixel_id code element', () => {
+    render(<TrackingWidget />);
+    const pixelIdElements = screen.getAllByText('pixel_id');
+    expect(pixelIdElements.length).toBeGreaterThan(0);
+  });
+
+  it('renders with page-body class', () => {
+    const { container } = render(<TrackingWidget />);
+    const pageBody = container.querySelector('.page-body');
+    expect(pageBody).toBeInTheDocument();
+  });
+
+  it('renders deployment steps', () => {
+    render(<TrackingWidget />);
+    expect(screen.getByText(/Get your Muntra Pixel ID/)).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,3 @@
-html {
-}
-
 body {
   margin: 0px !important;
   height: 100vh;
@@ -38,9 +35,6 @@ code {
   background-color: rgba(27, 31, 35, 0.05);
   border-radius: 3px;
   font-size: 1rem;
-}
-
-#root {
 }
 
 .backButtonContainer {
@@ -138,7 +132,7 @@ code {
   visibility: hidden;
   white-space: nowrap;
 }
-.hint-to-bottom:hover {
+.HintToBottom:hover {
   opacity: 1;
   transform: translate(-50%, 8px);
   visibility: visible;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11043,11 +11043,6 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-vitals@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
-  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
-
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for all SVG components (BookingWidgetSVG, CloseIconSVG, LeftArrowSVG, ReferralWidgetSVG, TrackingWidgetSVG)
- Add unit tests for all main components (App, BookingWidget, HelpMenu, ReferralWidget, TrackingWidget)
- Move testing libraries (@testing-library/*) to devDependencies
- Add lint script to package.json
- Remove unused CSS rules and clean up empty selectors

## Test plan
- [x] Run `yarn test` to verify all tests pass
- [x] Run `yarn lint` to verify linting works
- [x] Verify the application still builds with `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)